### PR TITLE
Bugfix: wrong parameter for _create_index_name + remove invalid m2m check on add_field + added support for changing m2m through fields

### DIFF
--- a/ibm_db_django/schemaEditor.py
+++ b/ibm_db_django/schemaEditor.py
@@ -157,7 +157,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
             new_db_field = new_field.db_parameters(connection=self.connection)
             old_db_field_type = old_db_field['type']
             new_db_field_type = new_db_field['type'] 
-            
+
         if old_db_field_type != new_db_field_type:
             alter_field_data_type = True
                 
@@ -432,7 +432,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
             self.execute(
                 self.sql_create_unique % {
                     'table': self.quote_name(model._meta.db_table),
-                    'name': self._create_index_name(model._meta.db_table, [new_field.column], suffix="_uniq"),
+                    'name': self._create_index_name(model, [new_field.column], suffix="_uniq"),
                     'columns': self.quote_name(new_field.column),
                 }
             )    

--- a/ibm_db_django/schemaEditor.py
+++ b/ibm_db_django/schemaEditor.py
@@ -527,22 +527,12 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
         field._unique = False
         
         super(DB2SchemaEditor, self).add_field(model, field)
-        if( djangoVersion[0:2] < ( 1, 9 ) ):
-            if field.rel is not None and hasattr(field.rel,'through'):
-                rel_condition = field.rel.through._meta.auto_created
-            else:
-                rel_condition = False
-        else:
-            if field.remote_field is not None and hasattr(field.remote_field,'through'):
-                rel_condition = field.remote_field.through._meta.auto_created
-            else:
-                rel_condition = False
-                
-        if isinstance(field, ManyToManyField) and rel_condition:
+
+        if isinstance(field, ManyToManyField):
             return
         else:
             self._reorg_tables()
-        sql = None
+
         if notnull or unique or p_key:
             del_column = self.sql_delete_column % {'table': self.quote_name(model._meta.db_table), 'column': self.quote_name(field.column)}
             if notnull:


### PR DESCRIPTION
I fixed some bugs I experienced with the execution of django migrations:

With the changes for the django 2.0 support one _create_index_name call argument was changed. I guess it happened by mistake, since the other calls weren't:

https://github.com/ibmdb/python-ibmdb-django/pull/18/commits/9ce69f20ec79b6dddfe075287a7cba8f3b50fe14#diff-28dd935d8b6c5de25b8e30186f05ee9eR435

Nevertheless: **_create_index_name** expects a model as first argument, so this one currently fails if you try to add a unique constraint to an existing field.

The other change refers to: https://github.com/ibmdb/python-ibmdb/pull/319 by @chsymann89
Since the **ibm_db_django** files on the other repo haven't been updated for years, I picked it up here too. I fully agree with the pull request, because no field operations have to be done for ANY m2m-fields at that point. The base backend of django uses this check to find out if it needs to "autocreate" a through table or not (because it has it's own model). It exits the add_field call for m2m-fields just some lines after it because definition is None (django/db/backends/schema.py:433). Since the parent function is called before the check, the auto_create stuff is already done and we need to exit for every m2m field.

And last one:
The base backend of django supports the case that a m2m field with through argument can be changed (auto_create=False for new and old). Currently this is not supported by this db2 adapter. It's an easy one, because nothing has to be done in this case, so I added it (while checking if alter_fields works as expected). I also added an additional Exception-Message if through argument is added or removed by a migration (it's the one django uses).
