### PR TITLE
Added integer to boolean converter for BooleanFields and NullBooleanF…

### DIFF
--- a/ibm_db_django/operations.py
+++ b/ibm_db_django/operations.py
@@ -84,6 +84,8 @@ class DatabaseOperations ( BaseDatabaseOperations ):
         field_type = expression.output_field.get_internal_type()
         if field_type in ( 'BinaryField',  ):
             converters.append(self.convert_binaryfield_value)   
+        elif field_type in ( 'BooleanField', 'NullBooleanField' ):
+            converters.append(self.convert_booleanfield_value)
         #  else:
         #   converters.append(self.convert_empty_values)
         """Get a list of functions needed to convert field data.
@@ -132,6 +134,12 @@ class DatabaseOperations ( BaseDatabaseOperations ):
     if( djangoVersion[0:2] >= ( 1, 8 ) ):
         def convert_binaryfield_value( self,value, expression,connections, context ):
             return value    
+
+        def convert_booleanfield_value(self, value, expression, connections, context):
+            if value in (0, 1):
+                return bool(value)
+            return value
+
     else:
         def convert_binaryfield_value( self,value, expression, context ):
         # field_type = field.get_internal_type()
@@ -139,6 +147,11 @@ class DatabaseOperations ( BaseDatabaseOperations ):
         #    if value in ( 0, 1 ):
         #       return bool( value )
         #else:
+            return value
+
+        def convert_booleanfield_value(self, value, expression, context):
+            if value in (0, 1):
+                return bool(value)
             return value
  
     if( djangoVersion[0:2] >= ( 1, 8 ) ):


### PR DESCRIPTION
Bugfix for issue https://github.com/ibmdb/python-ibmdb-django/issues/33

I tested this changes with the following test-environments:

```
Django==1.7
ibm-db==2.0.8
ibm-db-django==1.2.0.0

Django==1.11.13
ibm-db==2.0.8
ibm-db-django==1.2.0.0
```

Using the test-script provided in the issue I'm now receiving the desired booleans in the response.

```
Check memory-objects:
written: 0, read: 0
written: False, read: False
written: 1, read: 1
written: True, read: True

Check objects refreshed from database:
written: 0, read: False
written: False, read: False
written: 1, read: True
written: True, read: True
```