### PR TITLE
Removed DatabaseFeatures.can_introspect_max_length (moved from ibm_db)

### DIFF
--- a/ibm_db_django/base.py
+++ b/ibm_db_django/base.py
@@ -115,7 +115,7 @@ class DatabaseFeatures( BaseDatabaseFeatures ):
     can_introspect_boolean_field = False
     can_introspect_positive_integer_field = False
     can_introspect_small_integer_field = True
-    can_introspect_null = True    
+    can_introspect_null = True
     can_introspect_ip_address_field = False
     can_introspect_time_field = True
     

--- a/ibm_db_django/base.py
+++ b/ibm_db_django/base.py
@@ -115,8 +115,7 @@ class DatabaseFeatures( BaseDatabaseFeatures ):
     can_introspect_boolean_field = False
     can_introspect_positive_integer_field = False
     can_introspect_small_integer_field = True
-    can_introspect_null = True
-    can_introspect_max_length = True
+    can_introspect_null = True    
     can_introspect_ip_address_field = False
     can_introspect_time_field = True
     


### PR DESCRIPTION
This PR is to address the original [PR ](https://github.com/ibmdb/python-ibmdb/pull/252) raised on ibm_db

