### PR TITLE
Fix "ImportError: cannot import name 'six' from 'django.utils'"

### DIFF
--- a/ibm_db_django/schemaEditor.py
+++ b/ibm_db_django/schemaEditor.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 
-from django.utils import six
+import six
 from django.db import models
 from django.db.backends.utils import truncate_name
 from django.db.models.fields.related import ManyToManyField
@@ -51,12 +51,12 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_unique = "ALTER TABLE %(table)s DROP CONSTRAINT %(name)s"
     sql_drop_pk = "ALTER TABLE %(table)s DROP PRIMARY KEY"
     sql_drop_default = "ALTER TABLE %(table)s ALTER COLUMN %(column)s DROP DEFAULT"
-    
+
     @property
     def sql_create_pk(self):
         self._reorg_tables()
         return "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s PRIMARY KEY (%(columns)s)"
-    
+
     # return column definition DDL
     def column_sql(self, model, field, include_default=True):
         db_parameter = field.db_parameters(connection=self.connection)
@@ -71,9 +71,9 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                     if isinstance(field,models.BinaryField ):
                         if (value=="''"):
                             value  = 'EMPTY_BLOB()'
-                        else:                       
+                        else:
                             value='blob( %s'  %value + ')'
-                                            
+
                 sql += " DEFAULT %s" % value
             else:
                 field.default = None
@@ -102,7 +102,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
         else:
             value = str(value)
         return value
-    
+
     def alter_field(self, model, old_field, new_field, strict=False):
         alter_field_data_type = False
         alter_field_nullable = False
@@ -119,7 +119,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                           'unique': {},
                           'index': {},
                           'check': {}}
-        
+
         old_db_field = old_field.db_parameters(connection=self.connection)
         new_db_field = new_field.db_parameters(connection=self.connection)
         old_db_field_type = old_db_field['type']
@@ -135,7 +135,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                 rel_condition = (old_field.remote_field.through and new_field.remote_field.through and old_field.remote_field.through._meta.auto_created and new_field.remote_field.through._meta.auto_created)
             else:
                 rel_condition = False
-            
+
         if ((old_db_field_type, new_db_field_type) == (None, None)) and rel_condition:
                 return self._alter_many_to_many(model, old_field, new_field, strict)
         elif old_db_field_type is None or new_db_field_type is None:
@@ -143,7 +143,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                     old_db_field,
                     new_db_field,
                 ))
-            
+
         #Need to change datatype which need remaking of field
         if (old_db_field_type != new_db_field_type) and (isinstance(old_field, (models.AutoField, models.TextField)) or isinstance(new_field, models.TextField)):
             if old_field.primary_key and new_field.primary_key:
@@ -156,11 +156,11 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
             old_db_field = old_field.db_parameters(connection=self.connection)
             new_db_field = new_field.db_parameters(connection=self.connection)
             old_db_field_type = old_db_field['type']
-            new_db_field_type = new_db_field['type'] 
-            
+            new_db_field_type = new_db_field['type']
+
         if old_db_field_type != new_db_field_type:
             alter_field_data_type = True
-                
+
         if old_field.column != new_field.column:
             alter_field_name = True
         if old_field.db_index != new_field.db_index:
@@ -173,13 +173,13 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
             alter_field_check_constraint = True
         if old_field.null != new_field.null:
             alter_field_nullable = True
-        
+
         old_default = self.effective_default(old_field)
         new_default = self.effective_default(new_field)
         if (old_field.default is not None) and old_field.has_default():
             if old_default != new_default:
                 alter_field_default = True
-            
+
         #Need to remove Primary Key
         if alter_field_primary_key and old_field.primary_key:
             if strict:
@@ -191,13 +191,13 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                     'table': self.quote_name(model._meta.db_table)
                 }
             )
-                            
+
         #Need to remove unique Key
         if alter_field_unique and old_field.unique or ( old_field.unique and alter_field_primary_key and not old_field.primary_key):
             unique_key_names = self._constraint_names(model, [old_field.column], unique=True)
             if strict and len(unique_key_names) != 1:
                 raise ValueError("Found wrong number of unique constraints for (table)s.(column)s" % {'table': model._meta.db_table, 'column': old_field.column})
-            
+
             for unique_key_name in unique_key_names:
                 self.execute(
                     self.sql_delete_unique % {
@@ -205,7 +205,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                         'name': unique_key_name
                     }
                 )
-                
+
         #Need to remove Index
         if alter_field_index and old_field.db_index:
             index_names = self._constraint_names(model, [old_field.column], index=True)
@@ -217,7 +217,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                         'name': index_name
                     }
                 )
-                
+
         #Need to remove check constraint
         if alter_field_check_constraint and old_db_field['check']:
             check_constraint_names = self._constraint_names(model, [old_field.column], check=True)
@@ -230,17 +230,17 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                         'name': check_constraint_name
                     }
                 )
-        
+
         #Need to remove Nullability
         if alter_field_nullable and old_field.null:
             sql = self.sql_alter_column_not_null % {'column': self.quote_name(old_field.column)}
             self.execute(
                 self.sql_alter_column % {
-                    'table': self.quote_name(model._meta.db_table), 
+                    'table': self.quote_name(model._meta.db_table),
                     'changes': sql
                 }
             )
-        
+
         #Drop all FK constraints, if require we will make it again
         if( djangoVersion[0:2] < ( 1, 9 ) ):
             flag= old_field.rel
@@ -255,9 +255,9 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                         'name': fk_name
                     }
                 )
-                
+
         if alter_field_name or alter_field_data_type:
-            
+
             #Drop all incoming FK constraint, if require we will make it again
             if old_field.primary_key and new_field.primary_key:
                 rebuild_incomming_fk = True
@@ -270,22 +270,22 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                                 'name': fk_name,
                             }
                         )
-                    
+
             #Defer constraint check
             with self.connection.cursor() as cur:
                 constraints = self.connection.introspection.get_constraints(cur, model._meta.db_table)
             self._defer_constraints_check(constraints, deferred_constraints, old_field, new_field, model, defer_pk=True, defer_unique=True, defer_index=True, defer_check=True)
-                    
+
             #Need to change the field name
             if alter_field_name:
                 self.execute(
                     self.sql_rename_column % {
                         'table': self.quote_name(model._meta.db_table),
                         'old_column': self.quote_name(old_field.column),
-                        'new_column': self.quote_name(new_field.column),  
+                        'new_column': self.quote_name(new_field.column),
                     }
                 )
-                
+
             #Need to change the field type
             if alter_field_data_type:
                 if old_field.primary_key and new_field.primary_key:
@@ -304,7 +304,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                     with self.connection.cursor() as cur:
                         cur.execute(
                             'SELECT MAX( %(column)s ) from %(table)s' % {
-                                    'column': self.quote_name(new_field.column), 
+                                    'column': self.quote_name(new_field.column),
                                     'table': self.quote_name(model._meta.db_table),
                             }
                         )
@@ -316,7 +316,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                     if not isinstance(old_field, models.IntegerField):
                         sql = self.sql_alter_column_type % {
                                     'column': self.quote_name(new_field.column),
-                                    'type': 'Integer'                      
+                                    'type': 'Integer'
                                 }
                         self.execute(
                             self.sql_alter_column % {
@@ -325,12 +325,12 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                             }
                         )
                     sql = self.sql_alter_column_type_from_int_to_auto % {
-                                'column': self.quote_name(new_field.column), 
+                                'column': self.quote_name(new_field.column),
                                 'max': max+1
                                 }
                     self.execute(
                         self.sql_alter_column % {
-                            'table': self.quote_name(model._meta.db_table), 
+                            'table': self.quote_name(model._meta.db_table),
                             'changes': sql
                         }
                     )
@@ -345,10 +345,10 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                             'changes': sql
                         }
                     )
-                    
+
             #restore constraint checks
             self._restore_constraints_check(deferred_constraints, old_field, new_field, model)
-        
+
         #Need to change Default
         if alter_field_default:
             if new_default is None:
@@ -371,8 +371,8 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                         'changes': sql
                     }
                 )
-               
-        
+
+
         #Need to change nullability
         if alter_field_nullable:
             sql = ""
@@ -390,7 +390,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                     'changes': sql
                 }
             )
-        
+
         #Need to add check constraint
         if alter_field_check_constraint and new_db_field['check']:
             self.execute(
@@ -405,7 +405,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
         incoming_relations = []
         if alter_incomming_fk_data_type:
             incoming_relations.extend(new_field.model._meta.get_all_related_objects())
-            
+
         #Need to add new PK
         if alter_field_primary_key and new_field.primary_key:
             #Drop old PK if available
@@ -420,8 +420,8 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
             self.__model = model
             self.execute(
                 self.sql_create_pk % {
-                    'table': self.quote_name(model._meta.db_table), 
-                    'name': self._create_index_name(model, [new_field.column], suffix="_pk"), 
+                    'table': self.quote_name(model._meta.db_table),
+                    'name': self._create_index_name(model, [new_field.column], suffix="_pk"),
                     'columns': self.quote_name(new_field.column)
                 }
             )
@@ -435,7 +435,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                     'name': self._create_index_name(model._meta.db_table, [new_field.column], suffix="_uniq"),
                     'columns': self.quote_name(new_field.column),
                 }
-            )    
+            )
         #Need to add a index
         elif alter_field_index and new_field.db_index:
             self.execute(
@@ -460,7 +460,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                     'changes': sql
                 }
             )
-            
+
         #need to reorg table if we changed the field type of fk field
         if len(incoming_relations) > 0:
             self._reorg_tables()
@@ -500,13 +500,13 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                         'to_column': self.quote_name(new_field.column),
                     }
                 )
-                
+
 
     def alterFieldDataTypeByRemaking(self, model, old_field, new_field, strict):
         tmp_new_field = copy.deepcopy(new_field)
         tmp_new_field.column = truncate_name( "%s%s" % ( self.psudo_column_prefix, tmp_new_field.column ), self.connection.ops.max_name_length() )
         self.add_field(model, tmp_new_field)
-        
+
         #Transfer data from old field to new tmp field
         self.execute("UPDATE %s set %s=%s" % (
                 self.quote_name(model._meta.db_table),
@@ -515,8 +515,8 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
             )
         )
         self.remove_field(model, old_field)
-        return tmp_new_field, new_field   
-        
+        return tmp_new_field, new_field
+
     def add_field(self, model, field):
         self.__model = model
         notnull = not field.null
@@ -525,7 +525,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
         field.primary_key = False
         unique = field.unique
         field._unique = False
-        
+
         super(DB2SchemaEditor, self).add_field(model, field)
         if( djangoVersion[0:2] < ( 1, 9 ) ):
             if field.rel is not None and hasattr(field.rel,'through'):
@@ -537,7 +537,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                 rel_condition = field.remote_field.through._meta.auto_created
             else:
                 rel_condition = False
-                
+
         if isinstance(field, ManyToManyField) and rel_condition:
             return
         else:
@@ -583,10 +583,10 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                 except Error as e:
                     self.execute(del_column)
                     raise e
-            
+
     def alter_db_table(self, model, old_db_table, new_db_table):
         super(DB2SchemaEditor, self).alter_db_table(model, old_db_table, new_db_table)
-        
+
     def _alter_many_to_many(self, model, old_field, new_field, strict):
         deferred_constraints = {
                           'pk': {},
@@ -595,7 +595,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                           'check': {}}
 
         if( djangoVersion[0:2] < ( 1, 9 ) ):
-            if ((old_field.rel is not None and hasattr(old_field.rel,'through')) and 
+            if ((old_field.rel is not None and hasattr(old_field.rel,'through')) and
                (new_field.rel is not None and hasattr(new_field.rel,'through'))):
                 old_field_rel_through = old_field.rel.through
                 rel_old_field = old_field.rel.through._meta.get_field(old_field.m2m_reverse_field_name())[0]
@@ -604,7 +604,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                 rel_old_field = None
                 rel_new_field = None
         else:
-            if((old_field.remote_field is not None and hasattr(old_field.remote_field,'through')) and 
+            if((old_field.remote_field is not None and hasattr(old_field.remote_field,'through')) and
                 (new_field.remote_field is not None and hasattr(new_field.remote_field,'through'))):
                 old_field_rel_through = old_field.remote_field.through
                 rel_old_field = old_field.remote_field.through._meta.get_field(old_field.m2m_reverse_field_name())
@@ -627,7 +627,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
             self._reorg_tables()
             super(DB2SchemaEditor, self)._alter_many_to_many(model, old_field, new_field, strict)
             self._restore_constraints_check(deferred_constraints, rel_old_field, rel_new_field, new_field.rel.through)
-       
+
     def _reorg_tables(self):
         checkReorgSQL = "select TABSCHEMA, TABNAME from SYSIBMADM.ADMINTABINFO where REORG_PENDING = 'Y'"
         res = []
@@ -638,10 +638,10 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
         if res:
             for sName, tName in res:
                 reorgSQL = '''CALL SYSPROC.ADMIN_CMD('REORG TABLE "%(sName)s"."%(tName)s"')''' % {'sName': sName, 'tName': tName}
-                reorgSQLs.append(reorgSQL)      
+                reorgSQLs.append(reorgSQL)
         for sql in reorgSQLs:
             self.execute(sql)
-        
+
     def _defer_constraints_check(self, constraints, deferred_constraints, old_field, new_field, model, defer_pk=False, defer_unique=False, defer_index=False, defer_check=False):
         for constr_name, constr_dict in constraints.items():
             if defer_pk and constr_dict['primary_key'] is True:
@@ -655,7 +655,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                 if old_field.column in constr_dict['columns']:
                     try:
                         self.execute(self.sql_delete_unique % {
-                                            'table': model._meta.db_table, 
+                                            'table': model._meta.db_table,
                                             'name': constr_name})
                         deferred_constraints['unique'][constr_name] = constr_dict['columns']
                         continue
@@ -678,9 +678,9 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                                         'name': constr_name
                                 })
                     deferred_constraints['check'][constr_name] = constr_dict['columns']
-            
+
         return deferred_constraints
-    
+
     def _restore_constraints_check(self, deferred_constraints, old_field, new_field, model):
         self.__model = model
         for pk_name, columns in deferred_constraints['pk'].items():
@@ -699,4 +699,4 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
                                 'name': index_name,
                                 'columns': ', '.join(column.replace(old_field.column, new_field.column) for column in columns),
                                 'extra': ""})
-                                
+

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,14 @@ LICENSE = 'Apache License 2.0'
 extra = {}
 if sys.version_info >= (3, ):
     extra['use_2to3'] = True
-    
+
 setup (
     name              = PACKAGE,
     version           = VERSION,
     license           = LICENSE,
     platforms         = 'All',
     install_requires  = _IS_JYTHON and ['django>=1.0.3'] or ['ibm_db>=1.0.3',
-                          'django>=1.0.3'],
+                          'django>=1.0.3', 'six'],
     dependency_links  = _IS_JYTHON and ['http://pypi.python.org/pypi/Django/'] or ['http://pypi.python.org/pypi/ibm_db/',
                           'http://pypi.python.org/pypi/Django/'],
     description       = 'DB2 support for Django framework.',


### PR DESCRIPTION
Add `six` as `required_install` and replace all occurrencies of
`from django.utils import six` to 'import six`.

Fix the error `ImportError: cannot import name 'six' from 'django.utils'`
in Django >= 3.0