### PR TITLE
bugfixes in combine_expression

### DIFF
--- a/ibm_db_django/operations.py
+++ b/ibm_db_django/operations.py
@@ -116,17 +116,9 @@ class DatabaseOperations ( BaseDatabaseOperations ):
             return 'POWER(%s, %s)' % ( sub_expressions[0], sub_expressions[1] )
         elif operator == '-':
             if( djangoVersion[0:2] >= ( 2 , 0) ):
-                strr= str(sub_expressions[1])
-                sub_expressions[1] = strr.replace('+', '-')
-            else:
-                sub_expressions[1] = str.replace('+', '-')
+                sub_expressions[1] = str(sub_expressions[1]).replace('+', '-')
             return super( DatabaseOperations, self ).combine_expression( operator, sub_expressions )
         else:
-            if( djangoVersion[0:2] >= (2 , 0)):
-                strr= str(sub_expressions[1])
-                sub_expressions[1]=strr.replace('+', '-')
-            else:
-                sub_expressions[1] = str.replace('+', '-')
             return super( DatabaseOperations, self ).combine_expression( operator, sub_expressions )
     
     if( djangoVersion[0:2] >= ( 1, 8 ) ):


### PR DESCRIPTION
Don't replace '+' with '-' in sub_expression of 'else' branch as it cause wrong result in operation such as "a / (b + c)". The fact it's identical to branch " operator == '-' " lead me to think it's a duplication error.
Additionally, i don't have a django 1.x handy to test but i think "sub_expressions[1] = str.replace('+', '-')" don't work ? It appear to be an artifact of a previous commit when the variable "str" existed and is also redundant with the first branch.