### PR TITLE
Signed-off-by: Wanderley de Souza wandss@gmail.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ For Django 3.2,
    {{{
    DATABASES = {
       'default': {
-         'ENGINE'     : 'ibm_db_django',
-         'NAME'       : 'mydb',
-         'USER'       : 'db2inst1',
-         'PASSWORD'   : 'ibmdb2',
-         'HOST'       : 'localhost',
-         'PORT'       : '50000',
-         'PCONNECT'   :  True,      #Optional property, default is false
+	 'ENGINE'       : 'ibm_db_django',
+         'NAME'         : 'mydb',
+         'USER'         : 'db2inst1',
+         'PASSWORD'     : 'ibmdb2',
+         'HOST'         : 'localhost',
+         'PORT'         : '50000',
+         'PCONNECT'     :  True,      #Optional property, default is false
+	 'CURRENTSCHEMA': 'MYSCHEMA'  #Required if the database schema is different than the instance owner (USER)
       }
    }
    }}}


### PR DESCRIPTION
I had to jump into source code to figure out how to connect to a DB2 when the instance owner USER doesn't match the SCHEMA configured in a data base. Inside the source files I could see that the CURRENTSCHEMA information can be retrieved from the database itself or pulled out from django settings file. Having this information here will make the documentation more accurate.