### PR TITLE
pybase: drop unused imports for Django >= 2.2

### DIFF
--- a/ibm_db_django/pybase.py
+++ b/ibm_db_django/pybase.py
@@ -43,7 +43,6 @@ if ( djangoVersion[0:2] >= ( 1, 5 )) and ( djangoVersion[0:2] <= ( 2, 2 )):
     from django.utils import six
     import re
 elif ( djangoVersion[0:2] > ( 2, 2 )):
-    from django.utils.encoding import force_bytes, force_text
     import six
     import re
 


### PR DESCRIPTION
Neither force_bytes or force_text are used. Initially I was going to replace force_text with force_str for Django 4 support (force_text was removed), but realised that neither of those functions are referenced anywhere.

Tested with Django 4.0.

Replaces #81 