### PR TITLE
schemaEditor: make primary keys enforced

### DIFF
--- a/ibm_db_django/schemaEditor.py
+++ b/ibm_db_django/schemaEditor.py
@@ -99,7 +99,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
     @property
     def sql_create_pk(self):
         self._reorg_tables()
-        return "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s PRIMARY KEY (%(columns)s)"
+        return "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s PRIMARY KEY (%(columns)s) ENFORCED"
 
     def effective_default(self, field):
         """Return a field's effective database default value."""
@@ -152,7 +152,7 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
         if not field.null or notnull and 'DEFAULT' in sql:
             sql += " NOT NULL"
         if field.primary_key:
-            sql += " PRIMARY KEY"
+            sql += " PRIMARY KEY ENFORCED"
         elif field.unique:
             sql += " UNIQUE"
         tablespace = field.db_tablespace or model._meta.db_tablespace


### PR DESCRIPTION
Discovered during runs of `./manage.py loaddata`, it turns out that for the version of DB2 I'm using (either 10 or 11) that primary keys are not ENFORCED by default. None of the primary key, unique key, or FK constraints were created as ENFORCED.

This would lead to an error when enable_constraint_checking() tries to set FK constraints to ENFORCED as the referenced keys would not themselves be ENFORCED.