### PR TITLE
Default to atomic transaction for migrations

### DIFF
--- a/ibm_db_django/base.py
+++ b/ibm_db_django/base.py
@@ -93,6 +93,8 @@ class DatabaseFeatures( BaseDatabaseFeatures ):
 
     #transaction is supported by DB2
     supports_transactions = True
+    #Support for atomic migrations
+    can_rollback_ddl = True
 
     supports_tablespaces = True
 


### PR DESCRIPTION
This will set the default behavior when running a migration. See:
https://github.com/django/django/blob/d22ba0763086f71fb6df8502162ea63944d166b1/django/db/migrations/migration.py#L123-L134 and
https://github.com/django/django/blob/d22ba0763086f71fb6df8502162ea63944d166b1/django/db/backends/postgresql/features.py#L30C2-L30C2 For the example in the default postgres driver.