### PR TITLE
Force organize by row on new tables

### DIFF
--- a/ibm_db_django/schemaEditor.py
+++ b/ibm_db_django/schemaEditor.py
@@ -72,6 +72,7 @@ def _related_non_m2m_objects(old_field, new_field):
 
 class DB2SchemaEditor(BaseDatabaseSchemaEditor):
     psudo_column_prefix = 'psudo_'
+    sql_create_table = "CREATE TABLE %(table)s (%(definition)s) ORGANIZE BY ROW"
     sql_delete_table = "DROP TABLE %(table)s"
     sql_rename_table = "RENAME TABLE %(old_table)s TO %(new_table)s"
     sql_create_column = "ALTER TABLE %(table)s ADD COLUMN %(column)s %(definition)s"


### PR DESCRIPTION
If not specifed, DB2 will attempt to create new table based on the default organize by setting. If it set to column, using ALTER statement won't be possible. This will make even the default django migration fail (see auth.0002_alter_permission_name_max_length). With an explict ORGANIZE BY at the and of the table creation statement we explicitly set the table organization.

see more at
 - https://stackoverflow.com/questions/62717463/db2-and-django-why-tables-always-created-as-column-organized
 - https://www.ibm.com/docs/en/db2/11.5?topic=organization-setting-default-table